### PR TITLE
Feature/fix interrupts

### DIFF
--- a/gpio4/__init__.py
+++ b/gpio4/__init__.py
@@ -325,7 +325,7 @@ class GPIO(object):
             self._flag_interrupts_pause.clear()
             return
         self._thread_irq = threading.Thread(target=self._handle_interrupts)
-        self._thread_irq.setDeamon(True)
+        self._thread_irq.setDaemon(True)
         self._thread_irq.start()
 
     def disable_interrupts(self):
@@ -459,7 +459,7 @@ class _PWM:
         self._flag_pause = threading.Event()
         self._flag_stop = threading.Event()
         self._t = threading.Thread(target=self._pwm)
-        self._t.setDeamon(True)
+        self._t.setDaemon(True)
         self._t.start()
 
     def _pwm(self):

--- a/gpio4/__init__.py
+++ b/gpio4/__init__.py
@@ -223,6 +223,8 @@ class GPIO(object):
     _pwm_dict = {}
     _irq_dict = {}
     _flag_interrupts = threading.Event()
+    _flag_interrupts_pause = threading.Event()
+    _flag_interrupts_stop = threading.Event()
     _epoll = select.epoll()
 
     def __init__(self):
@@ -322,14 +324,15 @@ class GPIO(object):
 
     def enable_interrupts(self):
         if hasattr(self, '_thread_irq'):
-            self._flag_interrupts_pause.clear()
+            self._flag_interrupts_pause.set()
             return
         self._thread_irq = threading.Thread(target=self._handle_interrupts)
         self._thread_irq.setDaemon(True)
         self._thread_irq.start()
+        self._flag_interrupts_pause.set()
 
     def disable_interrupts(self):
-        self._flag_interrupts_pause.set()
+        self._flag_interrupts_pause.clear()
 
     def close_interrupts(self):
         self._flag_interrupts_stop.set()


### PR DESCRIPTION
Hi hanko,

I came across this library on pypi.org when searching for an alternative gpio lib for using on a BBB (BeagleBone Black) with BuildRoot. After I added a custom pinmapping I stumpled upon the the interrupts not working.
This library is awesome otherwise! I didn't find any other gpio sysfs library that had even support for add_event_detect() and the likes. Most just mimic the most basic functions of the RPi.GPIO Library.

Anyway, in this PR, I fixed the interrupts. I hope it's a worthwhile addition.

---

On another note: In [this commit](https://github.com/LinusCDE/gpio4/commit/75c24f7cb800bd20be6e09fa853d16f25933458f) I had to change the edge for both from "change" to "both" (as explained in the commits description). I have not added this here, since I don't know whether that was just a certainty for the [specific kernel I'm using](https://github.com/beagleboard/linux/tree/4.19.94-ti-rt-r43/). Do you happen to know more specifics on that one?

---

**EDIT**: Please also consider adding a release for v0.0.8. I pulled the v0.0.5 version and was stumped for a bit when setup() didn't work at all.