### PR TITLE
Fix for RPi

### DIFF
--- a/gpio4/constants.py
+++ b/gpio4/constants.py
@@ -20,6 +20,7 @@ class _sunxi():
 RISING       = 'rising'
 FALLING      = 'falling'
 CHANGE       = 'change'
+BOTH         = 'both'
 HIGH         = 1
 LOW          = 0
 INPUT        = 'in'
@@ -37,6 +38,7 @@ BOARD_SUNXI = _sunxi()
 BOARD_NANO_PI = {}
 BOARD_ORANGE_PI_PC = {}
 BCM = {}
+BOARD_RPI = {ix: ix for ix in range(28)}
 
 __all__ = ['RISING', 'FALLING', 'CHANGE', 'HIGH', 'LOW',
            'OUTPUT', 'INPUT', 'INPUT_PULLUP', 'INPUT_PULLDN',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gpio4",
-    version="0.0.8",
+    version="0.1.3",
     author="hankso",
     author_email="hankso1106@gmail.com",
     description=("Improved gpio module based on Sysfs, "


### PR DESCRIPTION
I try to use this python lib on RPi 3 and I have detected some errors.

- simple definition for RPI.BOARD and RPI uses edge `both` instead `change`
- mess with `_flag_interrupts*` 
- typo `setDeamon` and `remove`
- missing instancing of class GPIO